### PR TITLE
WebIntent keep intent info onNewIntent

### DIFF
--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -160,6 +160,7 @@ public class WebIntent extends CordovaPlugin {
         if (this.onNewIntentCallbackContext != null) {
             PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
             result.setKeepCallback(true);
+            this.cordova.getActivity().setIntent(intent);
             this.onNewIntentCallbackContext.sendPluginResult(result);
         }
     }


### PR DESCRIPTION
This helps to allow calls to hasExtra and getExtra after a newIntent event was fired. Otherwise, you will always stay on the first intent received
This is important if you use launchMode singleTop or singleInstance where onNewIntent can be fired multiple times.