### PR TITLE
Intent flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Here is an example of using webintent to open an Android .apk package, which the
 window.plugins.webintent.startActivity({
       action: window.plugins.webintent.ACTION_VIEW,
       url: 'file://' + theFile.fullPath,
-      type: 'application/vnd.android.package-archive'
+      type: 'application/vnd.android.package-archive',
+      flag: window.plugins.webintent.FLAG_ACTIVITY_NEW_TASK
     },
     function () {},
     function () {

--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -55,6 +55,8 @@ public class WebIntent extends CordovaPlugin {
                 Uri uri = obj.has("url") ? resourceApi.remapUri(Uri.parse(obj.getString("url"))) : null;
                 JSONObject extras = obj.has("extras") ? obj.getJSONObject("extras") : null;
                 Map<String, String> extrasMap = new HashMap<String, String>();
+                Object flagParse = obj.get("flag");
+                Integer flag = (flagParse instanceof Integer) ? (int) flagParse : (int) Integer.parseInt((String) flagParse);
 
                 // Populate the extras if any exist
                 if (extras != null) {
@@ -66,7 +68,7 @@ public class WebIntent extends CordovaPlugin {
                     }
                 }
 
-                startActivity(obj.getString("action"), uri, type, extrasMap);
+                startActivity(obj.getString("action"), uri, type, extrasMap, flag);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
                 return true;
             } else if ("hasExtra".equals(action)) {
@@ -165,7 +167,7 @@ public class WebIntent extends CordovaPlugin {
         }
     }
 
-    void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
+    void startActivity(String action, Uri uri, String type, Map<String, String> extras, Integer flag) {
         Intent i = uri != null ? new Intent(action, uri) : new Intent(action);
 
         if (type != null && uri != null) {
@@ -193,6 +195,9 @@ public class WebIntent extends CordovaPlugin {
             } else {
                 i.putExtra(key, value);
             }
+        }
+        if(flag != null){
+            i.setFlags(flag);
         }
         ((CordovaActivity)this.cordova.getActivity()).startActivity(i);
     }

--- a/www/webintent.js
+++ b/www/webintent.js
@@ -16,6 +16,7 @@
     WebIntent.prototype.EXTRA_EMAIL = "android.intent.extra.EMAIL";
     WebIntent.prototype.ACTION_CALL = "android.intent.action.CALL";
     WebIntent.prototype.ACTION_SENDTO = "android.intent.action.SENDTO";
+    WebIntent.prototype.FLAG_ACTIVITY_NEW_TASK = "268435456";
 
     WebIntent.prototype.startActivity = function(params, success, fail) {
         return cordova.exec(function(args) {


### PR DESCRIPTION
Hello as you mention on README i am one of the many who had forked the original repository of Boris Smus to fix #14 but i never created a pull request.

This PR Add support for a single flag to support installing apk with webintent.startActivity and set the flag of the intent to FLAG_ACTIVITY_NEW_TASK as i have read back at the time from this [answer](https://stackoverflow.com/questions/14682554/install-newer-version-of-app-in-android-with-intent) on stackoverflow.

I am not sure if there is a use case where multiple flags can be set for one activity but this PR does not handle that case.