### PR TITLE
Rename to cordova-webintent for consistency; bump version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ canonical upstream, and submit PRs for any changes you'd like merged.**
 1. To install the plugin, use the Cordova CLI:
 
     ```bash
-    cordova plugin add https://github.com/cordova-misc/cordova-webintent.git
+    cordova plugin add github:cordova-misc/cordova-webintent.git
     ```
 
-1. Confirm that the following is now in your `config.xml` file:
+1. Confirm that the following is now in your `package.json` file:
 
-    ```xml
-    <plugin name="WebIntent" value="com.borismus.webintent.WebIntent" />
+    ```json
+    "cordova-webintent": "github:cordova-misc/cordova-webintent
     ```
 
 ## Sample code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-webintent",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "WebIntent Android Plugin for Cordova 3.X",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
     "intent"
   ],
   "author": "borismus",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/cordova-misc/cordova-webintent/issues"
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
-           id="com.borismus.webintent"
-      version="1.1.0">
-    <name>WebIntent</name>
+           id="cordova-webintent"
+      version="2.0.0">
+    <name>cordova-webintent</name>
     <description>Web intents for Cordova</description>
     <license>Apache</license>
     <keywords>cordova,webintent</keywords>


### PR DESCRIPTION
* Now that Cordova favors package.json over config.xml for plugin versioning, renaming the plugin and changing the id to cordova-webintent ensures that there are no redundant plugin declarations (cordova-webintent, com.borismus.webintent). Additionally, the plugin ID change prevents Cordova from fetching the com.borismus.webintent plugin published on npm.
* Bumping the version to 2.0.0, since the rename is not backwards compatible.